### PR TITLE
🐛 Run From file page goto

### DIFF
--- a/harambe/core.py
+++ b/harambe/core.py
@@ -313,7 +313,6 @@ class SDK:
                     listing["context"],
                 )
 
-
     @staticmethod
     def scraper(
         domain: str, stage: Stage

--- a/harambe/harness.py
+++ b/harambe/harness.py
@@ -23,7 +23,7 @@ async def playwright_harness(headless: bool) -> AsyncGenerator[Page, None]:
             viewport={"width": 1280, "height": 1024},
             ignore_https_errors=True,
             user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
-                       " (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+            " (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
         )
 
         ctx.set_default_timeout(60000)


### PR DESCRIPTION
- make the sdk go to the page when using sdk.run_from_file
- extract duplicated code into shared function