### PR TITLE
Add support for specifying setup function

### DIFF
--- a/harambe/types.py
+++ b/harambe/types.py
@@ -5,3 +5,4 @@ ScrapeResult = Dict[str, Any]
 Context = Dict[str, Any]
 Stage = Literal["category", "listing", "detail"]
 AsyncScraperType = Callable[["SDK", URL, Context], Awaitable[None]]  # noqa: F821
+SetupType = Callable[["SDK"], Awaitable[None]]  # noqa: F821


### PR DESCRIPTION
Using this, I was able to shave off 5 seconds from a small one-page target (16 seconds vs. 21), 30 seconds from a large one-page target (125 seconds vs. 155).

It also makes it possible to run Harambe using .har files while being completely offline (tested on two example websites, had no network connection).
