### PR TITLE
Make Docker ignore temporary directory created by Ruff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.ruff_cache/


### PR DESCRIPTION
Otherwise it needs to be removed manually every time before running `make test` and other commands that use `docker run`