### PR TITLE
🐛 Add Fix for PDFs URLs Issue

### DIFF
--- a/harambe/contrib/soup/impl.py
+++ b/harambe/contrib/soup/impl.py
@@ -69,6 +69,9 @@ class SoupPage(AbstractPage[SoupElementHandle]):
     def url(self) -> str:
         return self._url
 
+    def set_url(self, url: str) -> None:
+        self._url = url
+
     async def goto(self, url: str, **kwargs: Any) -> None:
         res = await self._session.get(
             url, headers=self._extra_headers, impersonate="chrome"

--- a/harambe/contrib/soup/impl.py
+++ b/harambe/contrib/soup/impl.py
@@ -69,8 +69,9 @@ class SoupPage(AbstractPage[SoupElementHandle]):
     def url(self) -> str:
         return self._url
 
-    def set_url(self, url: str) -> None:
-        self._url = url
+    @url.setter
+    def url(self, value: str) -> None:
+        self._url = value
 
     async def goto(self, url: str, **kwargs: Any) -> None:
         res = await self._session.get(

--- a/harambe/core.py
+++ b/harambe/core.py
@@ -24,7 +24,7 @@ from playwright.async_api import (
     TimeoutError as PlaywrightTimeoutError,
 )
 
-from harambe.contrib import WebHarness, playwright_harness, soup_harness
+from harambe.contrib import WebHarness, playwright_harness
 from harambe.contrib.types import AbstractPage
 from harambe.handlers import (
     ResourceRequestHandler,

--- a/harambe/core.py
+++ b/harambe/core.py
@@ -14,7 +14,6 @@ from typing import (
     Union,
     Unpack,
 )
-from harambe.contrib.soup.impl import SoupPage
 import aiohttp
 from playwright.async_api import (
     ElementHandle,
@@ -25,6 +24,7 @@ from playwright.async_api import (
 )
 
 from harambe.contrib import WebHarness, playwright_harness
+from harambe.contrib.soup.impl import SoupPage
 from harambe.contrib.types import AbstractPage
 from harambe.handlers import (
     ResourceRequestHandler,
@@ -338,9 +338,8 @@ class SDK:
 
             if not harness_options.get("disable_go_to_url", False):
                 await page.goto(url)
-            else:
-                if isinstance(page, SoupPage):
-                    page.set_url(url)
+            elif isinstance(page, SoupPage):
+                page.url = url
             await scraper(sdk, url, context)
 
         return sdk

--- a/harambe/core.py
+++ b/harambe/core.py
@@ -14,7 +14,7 @@ from typing import (
     Union,
     Unpack,
 )
-
+from harambe.contrib.soup.impl import SoupPage
 import aiohttp
 from playwright.async_api import (
     ElementHandle,
@@ -24,7 +24,7 @@ from playwright.async_api import (
     TimeoutError as PlaywrightTimeoutError,
 )
 
-from harambe.contrib import WebHarness, playwright_harness
+from harambe.contrib import WebHarness, playwright_harness, soup_harness
 from harambe.contrib.types import AbstractPage
 from harambe.handlers import (
     ResourceRequestHandler,
@@ -338,6 +338,9 @@ class SDK:
 
             if not harness_options.get("disable_go_to_url", False):
                 await page.goto(url)
+            else:
+                if isinstance(page, SoupPage):
+                    page.set_url(url)
             await scraper(sdk, url, context)
 
         return sdk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ email-validator = "^2.2.0"
 phonenumbers = "^8.13.43"
 curl-cffi = "^0.7.1"
 ua-generator = "^1.0.3"
-html2text = "^2024.2.26"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.4.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harambe-sdk"
-version = "0.25.0"
+version = "0.25.1"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = ["awtkns <hello@awtkns.com>"]
 readme = "README.md"
@@ -22,6 +22,7 @@ email-validator = "^2.2.0"
 phonenumbers = "^8.13.43"
 curl-cffi = "^0.7.1"
 ua-generator = "^1.0.3"
+html2text = "^2024.2.26"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.4.10"

--- a/test/test_e2e.py
+++ b/test/test_e2e.py
@@ -397,3 +397,19 @@ async def test_required_feilds(server, harness):
             headless=True,
             harness=harness,
         )
+
+
+@pytest.mark.parametrize("harness", [soup_harness])
+async def test_disable_go_to_url_bug(server, harness):
+    async def scraper(sdk: SDK, *args, **kwargs):
+        page = sdk.page
+        await sdk.save_data({"url": page.url})
+
+    await SDK.run(
+        scraper=scraper,
+        disable_go_to_url=True,
+        url="https://www.bcp.gov.gh/acc/registry/docs/Ghana%20Export%20Promotion%20Authority%20Act,%201969%20(NLCD%20396).pdf",
+        schema={"url": {"type": "url"}},
+        headless=True,
+        harness=harness,
+    )


### PR DESCRIPTION
Ensure that page.url is assigned to the current page URL even if we do not visit the page.

Add an E2E test for the scenario where we visit a PDF link and save it directly without navigating to the page.