### PR TITLE
🚀 Add Local Storage Handling to SDK

### DIFF
--- a/harambe/core.py
+++ b/harambe/core.py
@@ -313,9 +313,9 @@ class SDK:
                 "() => Object.entries(localStorage).map(([key, value]) => ({key, value}))"
             )
 
-        existing_local_storage = existing_local_storage.update(
-            {[item["key"]]: item["value"] for item in local_storage}
-        )
+        for item in local_storage:
+            existing_local_storage[item["key"]] = item["value"]
+
         self._saved_local_storage = [
             {"key": key, "value": value}
             for key, value in existing_local_storage.items()

--- a/harambe/core.py
+++ b/harambe/core.py
@@ -313,8 +313,9 @@ class SDK:
                 "() => Object.entries(localStorage).map(([key, value]) => ({key, value}))"
             )
 
-        for item in local_storage:
-            existing_local_storage[item["key"]] = item["value"]
+        existing_local_storage = existing_local_storage.update(
+            {[item["key"]]: item["value"] for item in local_storage}
+        )
         self._saved_local_storage = [
             {"key": key, "value": value}
             for key, value in existing_local_storage.items()

--- a/harambe/observer.py
+++ b/harambe/observer.py
@@ -14,7 +14,12 @@ from harambe.tracker import FileDataTracker
 from harambe.types import URL, Context, Options, Stage, Cookie, LocalStorage
 
 ObservationTrigger = Literal[
-    "on_save_data", "on_queue_url", "on_download", "on_paginate", "on_save_cookies"
+    "on_save_data",
+    "on_queue_url",
+    "on_download",
+    "on_paginate",
+    "on_save_cookies",
+    "on_save_local_storage",
 ]
 
 

--- a/harambe/pagination.py
+++ b/harambe/pagination.py
@@ -3,7 +3,7 @@ import json
 from typing import Any, Optional, Iterable, List
 from pydantic import BaseModel
 
-from harambe.types import URL, Context, Options, Cookie
+from harambe.types import URL, Context, Options, Cookie, LocalStorage
 
 
 class PageInfo(BaseModel):
@@ -35,7 +35,7 @@ class DuplicateHandler:
         """
         return self._add_data(cookies)
 
-    def on_save_local_storage(self, local_storage: List[dict[str, Any]]):
+    def on_save_local_storage(self, local_storage: List[LocalStorage]):
         """
         Save local storage and check if they are duplicated
         :param local_storage: local storage to be saved

--- a/harambe/pagination.py
+++ b/harambe/pagination.py
@@ -35,6 +35,14 @@ class DuplicateHandler:
         """
         return self._add_data(cookies)
 
+    def on_save_local_storage(self, local_storage: List[dict[str, Any]]):
+        """
+        Save local storage and check if they are duplicated
+        :param local_storage: local storage to be saved
+        :return: bool indicating if the local storage is duplicated, true if it is duplicated
+        """
+        return self._add_data(local_storage)
+
     def on_queue_url(
         self, url: URL, _: Optional[Context], __: Optional[Options]
     ) -> bool:

--- a/harambe/types.py
+++ b/harambe/types.py
@@ -97,3 +97,10 @@ class Cookie(TypedDict):
     secure: bool
     session: bool
     sameSite: str
+
+
+class LocalStorage(TypedDict):
+    domain: str
+    path: str | None
+    key: str
+    value: str


### PR DESCRIPTION
- Added a `save_local_storage` method to store local storage data from the browser or use provided data.
- Automatically updates existing local storage keys with new values.
- Notifies observers of the saved local storage changes.