### PR TITLE
🚫 Prevent email popups from `mailto:` and `tel:` links

### DIFF
--- a/harambe/contrib/playwright/harness.py
+++ b/harambe/contrib/playwright/harness.py
@@ -88,6 +88,13 @@ async def playwright_harness(
 
         async def page_factory(*_: Any, **__: Any) -> PlaywrightPage:
             page = await ctx.new_page()
+            page.on("dialog", lambda dialog: dialog.dismiss())
+            await page.route(
+                "**/*",
+                lambda route, request: route.abort()
+                if request.url.startswith(("mailto:", "tel:"))
+                else route.continue_(),
+            )
             if on_new_page:
                 await on_new_page(page)
             if stealth:

--- a/harambe/core.py
+++ b/harambe/core.py
@@ -362,6 +362,15 @@ class SDK:
 
             if not harness_options.get("disable_go_to_url", False):
                 await page.goto(url)
+                await page.wait_for_load_state("domcontentloaded")
+                await page.evaluate("""
+                        document.addEventListener('click', (event) => {
+                            const target = event.target.closest('a[href^="mailto:"], a[href^="tel:"]');
+                            if (target) {
+                                event.preventDefault();
+                            }
+                        });
+                    """)
             elif isinstance(page, SoupPage):
                 page.url = url
             await scraper(sdk, url, context)

--- a/harambe/core.py
+++ b/harambe/core.py
@@ -359,18 +359,18 @@ class SDK:
             )
             if setup:
                 await setup(sdk)
-
             if not harness_options.get("disable_go_to_url", False):
                 await page.goto(url)
-                await page.wait_for_load_state("domcontentloaded")
-                await page.evaluate("""
-                        document.addEventListener('click', (event) => {
-                            const target = event.target.closest('a[href^="mailto:"], a[href^="tel:"]');
-                            if (target) {
-                                event.preventDefault();
-                            }
-                        });
-                    """)
+                if harness == playwright_harness:
+                    await page.wait_for_load_state("domcontentloaded")
+                    await page.evaluate("""
+                            document.addEventListener('click', (event) => {
+                                const target = event.target.closest('a[href^="mailto:"], a[href^="tel:"]');
+                                if (target) {
+                                    event.preventDefault();
+                                }
+                            });
+                        """)
             elif isinstance(page, SoupPage):
                 page.url = url
             await scraper(sdk, url, context)

--- a/harambe/handlers.py
+++ b/harambe/handlers.py
@@ -94,7 +94,6 @@ class MailtoTelBlockerHandler:
     async def handle(self, route: Route) -> None:
         request_url = route.request.url
 
-        # Check if the request is a 'mailto:' or 'tel:' link and abort it
         if request_url.startswith(("mailto:", "tel:")):
             await route.abort("blockedbyclient")
         else:

--- a/harambe/handlers.py
+++ b/harambe/handlers.py
@@ -88,3 +88,14 @@ class UnnecessaryResourceHandler(AbstractHandler):
             return
 
         await route.fallback()
+
+
+class MailtoTelBlockerHandler:
+    async def handle(self, route: Route) -> None:
+        request_url = route.request.url
+
+        # Check if the request is a 'mailto:' or 'tel:' link and abort it
+        if request_url.startswith(("mailto:", "tel:")):
+            await route.abort("blockedbyclient")
+        else:
+            await route.continue_()

--- a/test/mock_html/emails.html
+++ b/test/mock_html/emails.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Page for Testing Mailto and Tel Blocking</title>
+</head>
+<body>
+    <h1>Test Mailto and Tel Links</h1>
+
+    <p>
+        <a href="mailto:test@example.com">Email Us</a>
+    </p>
+
+    <p>
+        <a href="tel:+1234567890">Call Us</a>
+    </p>
+
+    <p>
+        <a href="https://example.com">Go to Example</a>
+    </p>
+</body>
+</html>


### PR DESCRIPTION
- Implemented `MailtoTelBlockerHandler` to intercept and block `mailto:` and `tel:` links at the network level.
- Added JS-based click prevention to stop client-side interaction with `mailto:` and `tel:` links.
- Enhanced E2E tests to verify that popups and navigation for email and phone links are properly blocked.
- Verified no dialogs or popups are triggered during user interactions with these links.