### PR TITLE
🚫 Fail scrapers if the initial goto call returns an error status code

### DIFF
--- a/core/harambe_core/errors.py
+++ b/core/harambe_core/errors.py
@@ -4,6 +4,13 @@ class HarambeException(Exception):
     pass
 
 
+class GotoError(HarambeException):
+    def __init__(self, url: str, status: int) -> None:
+        super().__init__(
+            f'Error calling goto("{url}"). Received unexpected status code: {status}'
+        )
+
+
 class SchemaValidationError(HarambeException):
     def __init__(self, message: str = None):
         super().__init__(message)

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.50.2"
+version = "0.51.0"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -141,7 +141,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.50.2"
+version = "0.51.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dateparser" },

--- a/sdk/harambe/contrib/types.py
+++ b/sdk/harambe/contrib/types.py
@@ -2,7 +2,7 @@ import abc
 
 # noinspection PyUnresolvedReferences,PyProtectedMember
 from contextlib import _AsyncGeneratorContextManager
-from typing import Any, Awaitable, Callable, Generic, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Generic, Optional, TypeVar, Protocol
 
 T = TypeVar("T", bound="AbstractElementHandle")
 WebHarness = Callable[
@@ -42,6 +42,12 @@ class Selectable(Generic[T], abc.ABC):
         raise NotImplementedError()
 
 
+class ResponseWithStatus(Protocol):
+    """Protocol for goto responses across all harnesses. Use minimal attributes required for current use cases."""
+
+    status: int
+
+
 class AbstractPage(Selectable[T], abc.ABC):
     @property
     @abc.abstractmethod
@@ -49,7 +55,7 @@ class AbstractPage(Selectable[T], abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def goto(self, url: str, **kwargs: Any) -> None:
+    async def goto(self, url: str, **kwargs: Any) -> ResponseWithStatus:
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -49,6 +49,7 @@ from harambe.types import (
     LocalStorage,
 )
 from harambe_core import SchemaParser, Schema
+from harambe_core.errors import GotoError
 from harambe_core.normalize_url import normalize_url
 from harambe_core.parser.expression import ExpressionEvaluator
 from playwright.async_api import (
@@ -468,9 +469,7 @@ class SDK:
             if not harness_options.get("disable_go_to_url", False):
                 response = await page.goto(url)
                 if response.status >= 400:
-                    raise RuntimeError(
-                        f"Got an unexpected status code of {response.status} when attempting to load the page"
-                    )
+                    raise GotoError(url, response.status)
             elif isinstance(page, SoupPage):
                 page.url = url
             await scraper(sdk, url, context)

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -55,7 +55,6 @@ from playwright.async_api import (
     ElementHandle,
     Page,
 )
-from playwright.async_api import Response
 from playwright.async_api import (
     TimeoutError as PlaywrightTimeoutError,
 )
@@ -467,13 +466,10 @@ class SDK:
                 await setup(sdk)
 
             if not harness_options.get("disable_go_to_url", False):
-                maybe_response = await page.goto(url)
-                if (
-                    maybe_response
-                    and (status := cast(Response, maybe_response).status) >= 400
-                ):
+                response = await page.goto(url)
+                if response.status >= 400:
                     raise RuntimeError(
-                        f"Got an unexpected status code of {status} when attempting to load the page"
+                        f"Got an unexpected status code of {response.status} when attempting to load the page"
                     )
             elif isinstance(page, SoupPage):
                 page.url = url

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -468,7 +468,10 @@ class SDK:
 
             if not harness_options.get("disable_go_to_url", False):
                 maybe_response = await page.goto(url)
-                if maybe_response and (status := cast(Response, maybe_response).status) >= 400:
+                if (
+                    maybe_response
+                    and (status := cast(Response, maybe_response).status) >= 400
+                ):
                     raise RuntimeError(
                         f"Got an unexpected status code of {status} when attempting to load the page"
                     )

--- a/sdk/harambe/user_agent.py
+++ b/sdk/harambe/user_agent.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Callable, Awaitable
+from typing import Callable, Awaitable, cast
 
 import ua_generator
 
@@ -19,4 +19,4 @@ async def compute_user_agent(factory: UserAgentFactory) -> str:
     if asyncio.iscoroutine(result):
         return await result
 
-    return result
+    return cast(str, result)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.50.2"
+version = "0.51.0"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.50.2",
+    "harambe_core==0.51.0",
     "pydantic==2.9.2",
     "playwright==1.47.0",
     "setuptools==73.0.0",

--- a/sdk/test/test_e2e.py
+++ b/sdk/test/test_e2e.py
@@ -551,7 +551,8 @@ async def test_with_locators(server, observer, harness):
     assert len(observer.data[0]["attachments"]) == 4
 
 
-async def test_403_status_on_goto(server, observer):
+@pytest.mark.parametrize("harness", [playwright_harness, soup_harness])
+async def test_403_status_on_goto(server, observer, harness):
     url = f"{server}/403"
 
     async def scrape(sdk: SDK, current_url, context) -> None:
@@ -563,6 +564,7 @@ async def test_403_status_on_goto(server, observer):
         await SDK.run(
             scrape,
             url,
+            harness=harness,
             schema={},
             context={"status": "Open"},
             observer=observer,

--- a/sdk/test/test_e2e.py
+++ b/sdk/test/test_e2e.py
@@ -5,6 +5,7 @@ import pytest
 from aiohttp import web
 from harambe.observer import InMemoryObserver
 from harambe.types import BrowserType
+from harambe_core.errors import GotoError
 
 from harambe import SDK
 from harambe.contrib import playwright_harness, soup_harness
@@ -560,7 +561,7 @@ async def test_403_status_on_goto(server, observer, harness):
             {"key": "this should't be saved as we're throwing an exception"}
         )
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(GotoError):
         await SDK.run(
             scrape,
             url,

--- a/sdk/test/test_harness.py
+++ b/sdk/test/test_harness.py
@@ -36,9 +36,10 @@ async def test_default_url(web_harness):
 
 
 async def test_with_two_connections():
-    async with playwright_harness(
-        launch_args=["--remote-debugging-port=9222"]
-    ) as p1, playwright_harness(cdp_endpoint="http://localhost:9222") as p2:
+    async with (
+        playwright_harness(launch_args=["--remote-debugging-port=9222"]) as p1,
+        playwright_harness(cdp_endpoint="http://localhost:9222") as p2,
+    ):
         page_1 = await p1()
         await page_1.goto("https://example.com/")
 

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.50.1"
+version = "0.51.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "dateparser" },
@@ -461,7 +461,7 @@ dev = [
 
 [[package]]
 name = "harambe-sdk"
-version = "0.50.1"
+version = "0.51.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes APE-382
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Scrapers now fail on error status codes from `goto` calls, with added support for job stages and updated tests.
> 
>   - **Behavior**:
>     - Scrapers in `core.py` fail if initial `goto` call returns error status code (>=400).
>     - Added `stage` parameter to `enqueue()` in `core.py` for job stages.
>   - **Functions**:
>     - Added `get_next_stage()` in `core.py` to determine next stage based on current stage.
>   - **Observer Changes**:
>     - Updated `on_queue_url()` in `observer.py` to include `stage` parameter.
>   - **Tests**:
>     - Added `test_403_status_on_goto()` in `test_e2e.py` to verify scraper failure on error status.
>     - Added `test_get_next_stage.py` to test `get_next_stage()` functionality.
>     - Updated `test_pagination.py` to ensure URLs across stages are not deduplicated.
>   - **Versioning**:
>     - Bumped version to `0.51.0` in `pyproject.toml` and `uv.lock` for both `core` and `sdk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for ca057520446409fcc95b4a8471d883b1084e8cee. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->