### PR TITLE
✨ Add trailing period stripping to email validation

### DIFF
--- a/core/harambe_core/parser/expression/functions.py
+++ b/core/harambe_core/parser/expression/functions.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from slugify import slugify as python_slugify
+# from slugify import slugify as python_slugify
 
 from harambe_core.parser.expression.evaluator import ExpressionEvaluator
 

--- a/core/harambe_core/parser/type_email.py
+++ b/core/harambe_core/parser/type_email.py
@@ -6,6 +6,7 @@ from pydantic import BeforeValidator, validate_email
 def _validate_email(value: str) -> str:
     if isinstance(value, str):
         value = value.strip().lower().removeprefix("mailto:")
+        value = value.rstrip(".")
         return validate_email(value)[1]
     return value
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.52.0"
+version = "0.52.1"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/test/parser/test_type_email.py
+++ b/core/test/parser/test_type_email.py
@@ -21,6 +21,11 @@ class _TestModel(BaseModel):
         ("user@example.museum", "user@example.museum"),
         ("Jane.Doe@Example.COM", "jane.doe@example.com"),
         ("special+chars@123.com", "special+chars@123.com"),
+        ("jane@doe.com.", "jane@doe.com"),
+        ("user@example.museum..", "user@example.museum"),
+        ("Jane.Doe@Example.COM...", "jane.doe@example.com"),
+        ("mailto:test@example.com....", "test@example.com"),
+        ("test@example.com...  ", "test@example.com"),
     ],
 )
 def test_parser_success(email, expected):

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.52.0"
+version = "0.52.1"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.52.0",
+    "harambe_core==0.52.1",
     "pydantic==2.9.2",
     "playwright==1.47.0",
     "setuptools==73.0.0",


### PR DESCRIPTION
Adds functionality to strip any number of trailing periods from email addresses during validation, along with test coverage. This maintains correct email normalization while handling edge cases with multiple trailing periods.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds trailing period stripping to email validation in `type_email.py` and updates tests in `test_type_email.py`.
> 
>   - **Behavior**:
>     - `_validate_email` in `type_email.py` now strips trailing periods from email addresses.
>     - Ensures email normalization by removing any number of trailing periods.
>   - **Tests**:
>     - Adds test cases in `test_type_email.py` to verify trailing period stripping.
>     - Tests include various cases with single and multiple trailing periods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for c6dcf4deebfbc3244ee1a0ed29e2a170fe28eda9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->