### PR TITLE
docs(readme): fix typo in the readme local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To get started, clone the repository and install the dependencies using the foll
 git clone https://github.com/reworkd/harambe.git
 cd harambe/sdk
 uv sync
-uv run playwright install sd --with-deps
+uv run playwright install chromium --with-deps
 ```
 
 Finally, you can verify that everything is working correctly by running the following command in the


### PR DESCRIPTION
### Description
Fixed typo in readme local development setup instructions


### Verification
Tested local dev setup on local


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `README.md` local development setup instructions for Playwright installation.
> 
>   - **Docs**:
>     - Fix typo in `README.md` local development setup instructions. Change `uv run playwright install sd --with-deps` to `uv run playwright install chromium --with-deps`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for 3b1e17b7c43506b7d72771552070f6ebbd15f130. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->