### PR TITLE
✨ Don't normalize S3 urls

### DIFF
--- a/core/harambe_core/normalize_url.py
+++ b/core/harambe_core/normalize_url.py
@@ -14,6 +14,8 @@ def normalize_url(path: str, base_path: str | None) -> str:
     if not is_s3_url(path):
         # We append actual URLs at the end of S3 urls occasionally
         # Normalization will turn https:// into http:/
+        # TODO: When we handle dynamic downloads in our worker, we need to remove this logic
+        #  we should also remove s3 as an allowed scheme all together
         path = _normalize(path)
     escaped_path = path.replace(" ", "%20")
 

--- a/core/harambe_core/normalize_url.py
+++ b/core/harambe_core/normalize_url.py
@@ -11,7 +11,10 @@ def normalize_url(path: str, base_path: str | None) -> str:
     """
     path = sanitize_scheme(path)
     validate_allowed_scheme(path)
-    path = _normalize(path)
+    if not is_s3_url(path):
+        # We append actual URLs at the end of S3 urls occasionally
+        # Normalization will turn https:// into http:/
+        path = _normalize(path)
     escaped_path = path.replace(" ", "%20")
 
     if base_path is None:
@@ -45,7 +48,12 @@ def sanitize_scheme(url: str) -> str:
     return base + url[last_scheme_index + 1 :] if last_scheme_index > 0 else url
 
 
-allowed_url_schemes = ["http", "https", "s3", "file"]
+s3_scheme = "s3"
+allowed_url_schemes = ["http", "https", s3_scheme, "file"]
+
+
+def is_s3_url(url: str) -> bool:
+    return urlparse(url).scheme == s3_scheme
 
 
 def validate_allowed_scheme(url: str, scheme_required: bool = False) -> None:

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.55.0"
+version = "0.56.0"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/test/parser/test_type_url.py
+++ b/core/test/parser/test_type_url.py
@@ -61,6 +61,11 @@ from harambe_core.parser.type_url import ParserTypeUrl
             "https://example.com",
             "https://example.com/doc1",
         ),
+        (
+            "s3://deworkd-local-files/5a9a3ac5-a572-494d-a888-8a065e6e3878/579c900dbfb97dae2fbf329cf6b3411a.pdf;https://example.com/",
+            "https://www.example.com",
+            "s3://deworkd-local-files/5a9a3ac5-a572-494d-a888-8a065e6e3878/579c900dbfb97dae2fbf329cf6b3411a.pdf;https://example.com/",
+        ),
     ],
 )
 def test_pydantic_type_url_validate_type_success(url, base_url_, expected):

--- a/core/test/test_normalize_url.py
+++ b/core/test/test_normalize_url.py
@@ -112,6 +112,11 @@ from harambe_core.normalize_url import normalize_url, sanitize_scheme
             "//primoliquors.com/cdn/shop/files/oxcuimdzbczobdeo248f.png?v=1727810919&width=1946",
             "https://primoliquors.com/cdn/shop/files/oxcuimdzbczobdeo248f.png?v=1727810919&width=1946",
         ),
+        (
+            "https://www.example.com",
+            "s3://deworkd-local-files/5a9a3ac5-a572-494d-a888-8a065e6e3878/579c900dbfb97dae2fbf329cf6b3411a.pdf;https://example.com/",
+            "s3://deworkd-local-files/5a9a3ac5-a572-494d-a888-8a065e6e3878/579c900dbfb97dae2fbf329cf6b3411a.pdf;https://example.com/",
+        ),
     ],
 )
 def test_normalize_url(base_path, url, expected):

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.55.0"
+version = "0.56.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dateparser" },

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.55.0"
+version = "0.56.0"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.55.0",
+    "harambe_core==0.56.0",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.55.0"
+version = "0.56.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "dateparser" },
@@ -459,7 +459,7 @@ dev = [
 
 [[package]]
 name = "harambe-sdk"
-version = "0.55.0"
+version = "0.56.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `normalize_url()` to skip normalization for S3 URLs and update version to 0.56.0.
> 
>   - **Behavior**:
>     - Modify `normalize_url()` in `normalize_url.py` to skip normalization for S3 URLs using `is_s3_url()`.
>     - Add `is_s3_url()` function to check if a URL is an S3 URL.
>   - **Tests**:
>     - Add test cases in `test_normalize_url.py` and `test_type_url.py` to verify S3 URLs are not normalized.
>   - **Versioning**:
>     - Update version to `0.56.0` in `pyproject.toml` and `uv.lock` for both `harambe-core` and `harambe-sdk`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for 03ae49d9fe6db5b5735b33c94d1d5cf680fa3288. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->