### PR TITLE
🔄 Added ignore goto error flag

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.57.0"
+version = "0.58.0"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.57.0"
+version = "0.58.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dateparser" },
@@ -502,7 +502,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -64,6 +64,10 @@ from playwright.async_api import (
 from harambe.contrib import WebHarness, playwright_harness
 
 
+async def default_goto_error_cb(url: str, status: int):
+    raise GotoError(url, status)
+
+
 class AsyncScraper(Protocol):
     """
     Protocol that all classed based scrapers should implement.
@@ -449,7 +453,7 @@ class SDK:
         harness: WebHarness = playwright_harness,
         evaluator: Optional[ExpressionEvaluator] = None,
         observer: Optional[OutputObserver | List[OutputObserver]] = None,
-        goto_error_cb: Optional[Callable[..., Awaitable[None]]] = None,
+        goto_error_cb: Callable[..., Awaitable[None]] = default_goto_error_cb,
         **harness_options: Unpack[HarnessOptions],
     ) -> "SDK":
         """

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -491,7 +491,10 @@ class SDK:
 
             if not harness_options.get("disable_go_to_url", False):
                 response = await page.goto(url)
-                if response.status >= 400:
+                if (
+                    not harness_options.get("ignore_goto_error", False)
+                    and response.status >= 400
+                ):
                     raise GotoError(url, response.status)
             elif isinstance(page, SoupPage):
                 page.url = url

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -453,7 +453,7 @@ class SDK:
         harness: WebHarness = playwright_harness,
         evaluator: Optional[ExpressionEvaluator] = None,
         observer: Optional[OutputObserver | List[OutputObserver]] = None,
-        goto_error_cb: Callable[..., Awaitable[None]] = default_goto_error_cb,
+        goto_error_cb: Callable[[str, int], Awaitable[None]] = default_goto_error_cb,
         **harness_options: Unpack[HarnessOptions],
     ) -> "SDK":
         """

--- a/sdk/harambe/types.py
+++ b/sdk/harambe/types.py
@@ -72,3 +72,4 @@ class HarnessOptions(TypedDict, total=False):
     on_start: Optional[Callback]
     on_end: Optional[Callback]
     extensions: Sequence[str]
+    ignore_goto_error: bool

--- a/sdk/harambe/types.py
+++ b/sdk/harambe/types.py
@@ -72,4 +72,3 @@ class HarnessOptions(TypedDict, total=False):
     on_start: Optional[Callback]
     on_end: Optional[Callback]
     extensions: Sequence[str]
-    ignore_goto_error: bool

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.57.0"
+version = "0.58.0"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.57.0",
+    "harambe_core==0.58.0",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",

--- a/sdk/test/test_e2e.py
+++ b/sdk/test/test_e2e.py
@@ -661,7 +661,7 @@ async def test_403_status_on_goto_with_custom_callback(
     async def scrape(sdk: SDK, current_url, context) -> None:
         await sdk.save_data({"key": "this shouldn't be saved if GotoError is raised"})
 
-    async def custom_error_handler(status_code, url, **kwargs):
+    async def custom_error_handler(url, status_code):
         print(f"Handled {status_code} for {url} gracefully.")
 
     error_callback = custom_error_handler
@@ -672,7 +672,7 @@ async def test_403_status_on_goto_with_custom_callback(
         schema={},
         context={"status": "Open"},
         observer=observer,
-        goto_error_cb=error_callback,
+        callback=error_callback,
     )
 
     # Ensure data is saved when error is handled (either with custom or no callback)

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.57.0"
+version = "0.58.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "dateparser" },
@@ -459,7 +459,7 @@ dev = [
 
 [[package]]
 name = "harambe-sdk"
-version = "0.57.0"
+version = "0.58.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1053,7 +1053,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ignore_goto_error` flag and custom error callback for HTTP errors in SDK, with tests and version update to 0.58.0.
> 
>   - **Behavior**:
>     - Add `ignore_goto_error` flag to `HarnessOptions` in `sdk/harambe/types.py`.
>     - Modify `run()` in `sdk/harambe/core.py` to use `goto_error_cb` for handling HTTP errors (status >= 400).
>   - **Tests**:
>     - Add `test_403_status_on_goto_with_default_callback` and `test_403_status_on_goto_with_custom_callback` in `sdk/test/test_e2e.py` to verify error handling with and without custom callbacks.
>   - **Misc**:
>     - Update version to `0.58.0` in `core/pyproject.toml` and `sdk/pyproject.toml`.
>     - Update `tzlocal` dependency marker in `core/uv.lock` and `sdk/uv.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for 6b84f40b7a1b8c2990caaf33f197b1601e636e54. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->