### PR TITLE
Added fake image response

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.58.0"
+version = "0.59.0"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.58.0"
+version = "0.59.0"
 source = { virtual = "." }
 dependencies = [
     { name = "dateparser" },

--- a/sdk/harambe/handlers.py
+++ b/sdk/harambe/handlers.py
@@ -1,4 +1,5 @@
 import re
+import base64
 from abc import ABC
 from typing import Any, Literal, Self
 
@@ -78,9 +79,14 @@ class UnnecessaryResourceHandler(AbstractHandler):
     async def handle(self, route: Route) -> None:
         resource_type = route.request.resource_type
         url = route.request.url
-
-        if (
-            resource_type in ["image", "media", "font"]
+        if resource_type in ["image", "media"]:
+            fake_img = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+            await route.fulfill(
+                body=base64.b64decode(fake_img), content_type="image/png"
+            )
+            return
+        elif (
+            resource_type == "font"
             or re.match(r"^data:(image|audio|video)", url)
             or re.match(r"social-widget|tracking-script|ads", url)
         ):

--- a/sdk/harambe/handlers.py
+++ b/sdk/harambe/handlers.py
@@ -22,6 +22,9 @@ ResourceType = Literal[
     "*",
 ]
 
+FAKE_IMAGE_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
 
 class AbstractHandler(ABC):
     async def handle(self, route: Route) -> None:
@@ -75,15 +78,12 @@ class ResourceRequestHandler(AbstractHandler):
         return self._new_pages[0] if self._new_pages else None
 
 
-class UnnecessaryResourceHandler(AbstractHandler):
+class UnnecessaryResourceHandler:
     async def handle(self, route: Route) -> None:
         resource_type = route.request.resource_type
         url = route.request.url
         if resource_type in ["image", "media"]:
-            fake_img = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-            await route.fulfill(
-                body=base64.b64decode(fake_img), content_type="image/png"
-            )
+            await route.fulfill( body=FAKE_IMAGE_BYTES,  content_type="image/png" )
             return
         elif (
             resource_type == "font"

--- a/sdk/harambe/handlers.py
+++ b/sdk/harambe/handlers.py
@@ -26,6 +26,7 @@ FAKE_IMAGE_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 )
 
+
 class AbstractHandler(ABC):
     async def handle(self, route: Route) -> None:
         raise NotImplementedError
@@ -83,7 +84,7 @@ class UnnecessaryResourceHandler:
         resource_type = route.request.resource_type
         url = route.request.url
         if resource_type in ["image", "media"]:
-            await route.fulfill( body=FAKE_IMAGE_BYTES,  content_type="image/png" )
+            await route.fulfill(body=FAKE_IMAGE_BYTES, content_type="image/png")
             return
         elif (
             resource_type == "font"

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.58.0"
+version = "0.59.0"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.58.0",
+    "harambe_core==0.59.0",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.58.0"
+version = "0.59.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "dateparser" },
@@ -459,7 +459,7 @@ dev = [
 
 [[package]]
 name = "harambe-sdk"
-version = "0.58.0"
+version = "0.59.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add fake image response for `image` and `media` resources in `UnnecessaryResourceHandler` and update `harambe-core` and `harambe-sdk` to version `0.59.0`.
> 
>   - **Behavior**:
>     - `UnnecessaryResourceHandler` in `handlers.py` now returns a fake image for `image` and `media` resource types using a base64 encoded PNG.
>   - **Version Updates**:
>     - Update `harambe-core` and `harambe-sdk` versions to `0.59.0` in `pyproject.toml` and `uv.lock`.
>     - Update `harambe_core` dependency in `sdk/pyproject.toml` to `0.59.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for be9b650b3463887e99c541373e35946b8683e841. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->