### PR TITLE
🐛 Make enqueue work on pages with no go to url

### DIFF
--- a/core/harambe_core/normalize_url.py
+++ b/core/harambe_core/normalize_url.py
@@ -19,7 +19,7 @@ def normalize_url(path: str, base_path: str | None) -> str:
         path = _normalize(path)
     escaped_path = path.replace(" ", "%20")
 
-    if base_path is None:
+    if base_path is None or base_path == "about:blank":
         return escaped_path
 
     validate_allowed_scheme(base_path, scheme_required=True)

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.59.0"
+version = "0.59.1"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -132,11 +132,11 @@ class SDK:
                 "`SDK.save_data` should be called with one dict at a time, not a list of dicts."
             )
 
-        url = self.page.url
+        source_url = self.page.url
         for d in data:
             if self._validator is not None:
-                d = self._validator.validate(d, base_url=self.page.url)
-            d["__url"] = url
+                d = self._validator.validate(d, base_url=source_url)
+            d["__url"] = source_url
             await self._notify_observers("on_save_data", d)
 
     async def enqueue(

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.59.0"
+version = "0.59.1"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.59.0",
+    "harambe_core==0.59.1",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",

--- a/sdk/test/test_sdk.py
+++ b/sdk/test/test_sdk.py
@@ -33,7 +33,6 @@ def test_sdk_init_assigns_correct_values():
     assert sdk._observers == [observer]
 
 
-@pytest.mark.asyncio
 async def test_sdk_save_data_calls_on_save_data_for_each_observer():
     page = AsyncMock(spec=Page)
     observer = AsyncMock(spec=OutputObserver)
@@ -44,7 +43,6 @@ async def test_sdk_save_data_calls_on_save_data_for_each_observer():
     assert observer.on_save_data.call_count == len(data)
 
 
-@pytest.mark.asyncio
 async def test_sdk_enqueue_calls_on_enqueue_url_for_each_observer():
     page = AsyncMock(spec=Page)
     page.url = "https://example.net"
@@ -82,7 +80,6 @@ def test_scraper_decorator_adds_observers_to_function(scraper):
     assert len(decorated_scraper.observer) == 2
 
 
-@pytest.mark.asyncio
 async def test_scraper_decorator_preserves_functionality_of_decorated_function(scraper):
     decorated_scraper = SDK.scraper("https://example.org", "listing")(scraper)
 
@@ -99,7 +96,6 @@ async def test_scraper_decorator_preserves_functionality_of_decorated_function(s
     sdk.save_data.assert_awaited_once_with({"baz": "qux"})
 
 
-@pytest.mark.asyncio
 async def test_sdk_save_data_saves_valid_data():
     page = AsyncMock(spec=Page)
     page.url = "https://example.net"
@@ -125,7 +121,6 @@ async def test_sdk_save_data_saves_valid_data():
     assert observer.on_save_data.call_count == 2
 
 
-@pytest.mark.asyncio
 async def test_sdk_save_data_does_not_save_invalid_data():
     page = AsyncMock(spec=Page)
     observer = AsyncMock(spec=OutputObserver)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix enqueue functionality for pages without a 'go to' URL by updating `normalize_url` and `save_data` methods, and enhance tests for validation.
> 
>   - **Behavior**:
>     - Update `normalize_url` in `normalize_url.py` to handle `base_path` as `None` or `"about:blank"`.
>     - Modify `save_data` in `core.py` to use `source_url` instead of `url` for data validation and storage.
>   - **Testing**:
>     - Add `test_enqueue_no_goto_url` in `test_e2e.py` to verify enqueue functionality without a 'go to' URL.
>     - Update existing tests in `test_e2e.py` and `test_sdk.py` to include `observer` parameter in `SDK.run` calls.
>   - **Misc**:
>     - Bump version in `pyproject.toml` files to `0.59.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for 4b8ab668dab170d4dd8013dd12fcf20e9ccf0857. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->