### PR TITLE
🚀 Add allow_forbidden_requests option in HarnessOptions

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.60.1"
+version = "0.60.2"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.59.5"
+version = "0.60.2"
 source = { virtual = "." }
 dependencies = [
     { name = "dateparser" },
@@ -502,7 +502,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [

--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -232,7 +232,7 @@ class SDK:
         self,
         clickable: ElementHandle,
         resource_type: ResourceType = "document",
-        timeout: Optional[int] = 10000,
+        timeout: int = 10000,
     ) -> URL | None:
         """
         Capture the url of a click event. This will click the element and return the url
@@ -533,7 +533,11 @@ class SDK:
 
             if not harness_options.get("disable_go_to_url", False):
                 response = await page.goto(url)
-                if response.status >= 400:
+
+                if (
+                    not harness_options.get("allow_forbidden_requests", False)
+                    and response.status >= 400
+                ):
                     await goto_error_handler(url, response.status, response.headers)
             elif isinstance(page, SoupPage):
                 page.url = url

--- a/sdk/harambe/types.py
+++ b/sdk/harambe/types.py
@@ -69,6 +69,7 @@ class HarnessOptions(TypedDict, total=False):
     viewport: Optional[ViewportSize]
     abort_unnecessary_requests: bool
     disable_go_to_url: bool
+    allow_forbidden_requests: bool
     on_start: Optional[Callback]
     on_end: Optional[Callback]
     extensions: Sequence[str]

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.60.1"
+version = "0.60.2"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.60.1",
+    "harambe_core==0.60.2",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -428,7 +428,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.59.5"
+version = "0.60.2"
 source = { editable = "../core" }
 dependencies = [
     { name = "dateparser" },
@@ -459,7 +459,7 @@ dev = [
 
 [[package]]
 name = "harambe-sdk"
-version = "0.59.5"
+version = "0.60.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1053,7 +1053,7 @@ name = "tzlocal"
 version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
 wheels = [


### PR DESCRIPTION
- Changed the `timeout` parameter in the `capture_url` function from `Optional[int]` to `int`.
- Added a check for `allow_forbidden_requests` in the `run` function to handle requests with status codes >= 400 only if the option is not set.
- Added a new `allow_forbidden_requests` field to the `HarnessOptions` class.