### PR TITLE
🫡 Ability to attach to current context

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.61.1"
+version = "0.62.0"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/sdk/harambe/types.py
+++ b/sdk/harambe/types.py
@@ -51,3 +51,5 @@ class HarnessOptions(TypedDict, total=False):
     on_end: Optional[Callback]
     launch_args: Sequence[str]
     extensions: Sequence[str]
+    attach_to_existing_context: bool
+    attach_to_existing_page: bool

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.61.1"
+version = "0.62.0"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.61.1",
+    "harambe_core==0.62.0",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add options to attach to existing browser contexts and pages in Playwright harness, updating version to 0.62.0.
> 
>   - **Behavior**:
>     - Add `attach_to_existing_context` and `attach_to_existing_page` options to `playwright_harness` in `harness.py` to allow attaching to existing browser contexts and pages.
>     - Modify context and page creation logic in `playwright_harness` to use existing contexts/pages if options are set and available.
>   - **Types**:
>     - Add `attach_to_existing_context` and `attach_to_existing_page` to `HarnessOptions` in `types.py`.
>   - **Versioning**:
>     - Update version to `0.62.0` in `core/pyproject.toml` and `sdk/pyproject.toml` to reflect new feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for 990a8037f97e284e6687a5a198a122dc7a6b067b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->