### PR TITLE
✨APE-909 feat(save_data): add url param to save_data

### DIFF
--- a/sdk/harambe/core.py
+++ b/sdk/harambe/core.py
@@ -119,25 +119,27 @@ class SDK:
         self._observers = observer
         self._deduper = deduper if deduper else DuplicateHandler()
 
-    async def save_data(self, *data: ScrapeResult, url: Optional[str] = None) -> None:
+    async def save_data(
+        self, *data: ScrapeResult, source_url: Optional[str] = None
+    ) -> None:
         """
         Save scraped data and validate its type matches the current schema
 
         :param data: Rows of data (as dictionaries) to save
-        :param url: Optional URL to associate with the data, defaults to current page URL
+        :param source_url: Optional URL to associate with the data, defaults to current page URL. Only use this if the source of the data is different than the current page when the data is saved
         :raises SchemaValidationError: If any of the saved data does not match the provided schema
         :example:
             >>> await sdk.save_data({ "title": "example", "description": "another_example" })
-            >>> await sdk.save_data({ "title": "example", "description": "another_example" }, url="https://www.example.com/product/example_id")
+            >>> await sdk.save_data({ "title": "example", "description": "another_example" }, source_url="https://www.example.com/product/example_id")
         """
         if len(data) == 1 and isinstance(data[0], list):
             raise TypeError(
                 "`SDK.save_data` should be called with one dict at a time, not a list of dicts."
             )
 
-        source_url = url or self.page.url
+        url = source_url or self.page.url
         base_url = await self._compute_base_url(self.page.url)
-        normalized_url = normalize_url(source_url, base_url)
+        normalized_url = normalize_url(url, base_url)
 
         for d in data:
             if self._validator is not None:

--- a/sdk/test/mock_html/table.html
+++ b/sdk/test/mock_html/table.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <title> Table Page </title>
 </head>
 <body>
 <h1>Food Prices</h1>

--- a/sdk/test/test_e2e.py
+++ b/sdk/test/test_e2e.py
@@ -631,7 +631,7 @@ async def test_capture_html_table(server, observer, harness):
     url = f"{server}/table"
 
     async def scraper(sdk: SDK, *args, **kwargs):
-        text_html_metadata = await sdk.capture_html(html_converter_type="text")
+        text_html_metadata = await sdk.capture_html("body", html_converter_type="text")
         await sdk.save_data({"text": text_html_metadata["text"]})
 
     await SDK.run(

--- a/sdk/test/test_e2e.py
+++ b/sdk/test/test_e2e.py
@@ -152,7 +152,7 @@ async def test_base_url_with_base_tag_in_metadata(server, observer, harness):
         await sdk.enqueue("tags/tag_base.asp")
         await sdk.save_data({"url": "tags/tag_base.asp"})
         await sdk.save_data(
-            {"url": f"{server}/tags/tag_base.asp"}, url="tags/tag_base4.asp"
+            {"url": f"{server}/tags/tag_base.asp"}, source_url="tags/tag_base4.asp"
         )
 
     await SDK.run(
@@ -860,16 +860,16 @@ async def test_save_data_with_url(server, observer, harness):
         title1 = (await (await page.query_selector("title")).inner_text()).strip()
         await sdk.save_data({"title": title1})
 
-        await sdk.save_data({"title": title1 + "1"}, url=f"{page.url}/1")
+        await sdk.save_data({"title": title1 + "1"}, source_url=f"{page.url}/1")
 
         await page.goto(f"{server}/table")
         title2 = (await (await page.query_selector("title")).inner_text()).strip()
         await sdk.save_data({"title": title2})
 
-        await sdk.save_data({"title": title2 + "2"}, url=f"{page.url}/2")
+        await sdk.save_data({"title": title2 + "2"}, source_url=f"{page.url}/2")
 
         # deduped
-        await sdk.save_data({"title": title2}, url=f"{page.url}/3")
+        await sdk.save_data({"title": title2}, source_url=f"{page.url}/3")
 
     await SDK.run(
         scraper=scraper,

--- a/sdk/test/test_e2e.py
+++ b/sdk/test/test_e2e.py
@@ -9,6 +9,7 @@ from harambe.contrib import playwright_harness, soup_harness
 from harambe.instrumentation import HarambeInstrumentation, InMemoryExporter
 from harambe_core.errors import GotoError
 from harambe_core.observer import InMemoryObserver
+
 from .matchers import assert_partial_object_in
 
 
@@ -843,3 +844,47 @@ async def test_sdk_log_method_soup(server, observer):
             harness=soup_harness,
             observer=observer,
         )
+
+
+@pytest.mark.parametrize("harness", [playwright_harness, soup_harness])
+async def test_save_data_with_url(server, observer, harness):
+    url = f"{server}/solicitation"
+
+    async def scraper(sdk: SDK, *args, **kwargs):
+        page = sdk.page
+
+        title1 = (await (await page.query_selector("title")).inner_text()).strip()
+        await sdk.save_data({"title": title1})
+
+        await sdk.save_data({"title": title1 + "1"}, url=f"{page.url}/1")
+
+        await page.goto(f"{server}/table")
+        title2 = (await (await page.query_selector("title")).inner_text()).strip()
+        await sdk.save_data({"title": title2})
+
+        await sdk.save_data({"title": title2 + "2"}, url=f"{page.url}/2")
+
+        # deduped
+        await sdk.save_data({"title": title2}, url=f"{page.url}/3")
+
+    await SDK.run(
+        scraper=scraper,
+        url=url,
+        schema={},
+        headless=True,
+        harness=harness,
+        observer=observer,
+    )
+
+    first_url = f"{server}/solicitation"
+    second_url = f"{server}/table"
+
+    assert len(observer.data) == 4
+    assert observer.data[0]["title"] == "PA - eMarketplace"
+    assert observer.data[0]["__url"] == first_url
+    assert observer.data[1]["title"] == "PA - eMarketplace1"
+    assert observer.data[1]["__url"] == f"{first_url}/1"
+    assert observer.data[2]["title"] == "Table Page"
+    assert observer.data[2]["__url"] == second_url
+    assert observer.data[3]["title"] == "Table Page2"
+    assert observer.data[3]["__url"] == f"{second_url}/2"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `SDK.save_data` to accept an optional `source_url` parameter and update tests accordingly.
> 
>   - **Behavior**:
>     - `save_data` in `SDK` now accepts an optional `source_url` parameter to associate data with a specific URL, defaulting to the current page URL if not provided.
>     - Normalizes the `source_url` using `normalize_url` with the computed base URL.
>   - **Tests**:
>     - Updated `test_base_url_with_base_tag_in_metadata` in `test_e2e.py` to test `save_data` with `source_url`.
>     - Added `test_save_data_with_url` in `test_e2e.py` to verify `save_data` functionality with different `source_url` values.
>   - **Misc**:
>     - Minor import reordering in `core.py` for better organization.
>     - Added a `<title>` tag to `table.html` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for 273264af012e9edc18a38d3d9095d1eb039f719e. You can [customize](https://app.ellipsis.dev/reworkd/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->