### PR TITLE
Base64 Encoding on_download

### DIFF
--- a/core/harambe_core/observer/serialization_observer.py
+++ b/core/harambe_core/observer/serialization_observer.py
@@ -38,7 +38,7 @@ class SerializationObserver(OutputObserver):
     async def on_download(
         self, download_url: str, filename: str, content: bytes, path: str
     ) -> "DownloadMeta":
-        encoded_content = base64.b64encode(content).decode("ascii")
+        encoded_content = "base64:" + base64.b64encode(content).decode("ascii")
 
         payload: Payload = {
             "type": "on_download",

--- a/core/harambe_core/observer/serialization_observer.py
+++ b/core/harambe_core/observer/serialization_observer.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any, Callable, TypeVar, TypedDict
 from urllib.parse import quote
 
@@ -37,12 +38,14 @@ class SerializationObserver(OutputObserver):
     async def on_download(
         self, download_url: str, filename: str, content: bytes, path: str
     ) -> "DownloadMeta":
+        encoded_content = base64.b64encode(content).decode("ascii")
+
         payload: Payload = {
             "type": "on_download",
             "data": {
                 "download_url": download_url,
                 "filename": filename,
-                "content": content.decode("utf-8"),
+                "content": encoded_content,
                 "path": path,
             },
         }

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-core"
-version = "0.77.4"
+version = "0.77.5"
 description = "Core types for harambe SDK 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }

--- a/core/test/observer/test_json_observer.py
+++ b/core/test/observer/test_json_observer.py
@@ -26,7 +26,7 @@ async def test_json_observer(capsys):
     captured = capsys.readouterr()
     assert (
         captured.out
-        == '{"type": "on_download", "data": {"download_url": "https://www.example.com", "filename": "example.html", "content": "Y29udGVudA==", "path": "path"}}\n'
+        == '{"type": "on_download", "data": {"download_url": "https://www.example.com", "filename": "example.html", "content": "base64:Y29udGVudA==", "path": "path"}}\n'
     )
     assert captured.err == ""
 

--- a/core/test/observer/test_json_observer.py
+++ b/core/test/observer/test_json_observer.py
@@ -26,7 +26,7 @@ async def test_json_observer(capsys):
     captured = capsys.readouterr()
     assert (
         captured.out
-        == '{"type": "on_download", "data": {"download_url": "https://www.example.com", "filename": "example.html", "content": "content", "path": "path"}}\n'
+        == '{"type": "on_download", "data": {"download_url": "https://www.example.com", "filename": "example.html", "content": "Y29udGVudA==", "path": "path"}}\n'
     )
     assert captured.err == ""
 

--- a/core/test/observer/test_serialization_observer.py
+++ b/core/test/observer/test_serialization_observer.py
@@ -58,7 +58,7 @@ def test_on_download(observer, published_events):
         "data": {
             "download_url": "http://files.example.com",
             "filename": "test.txt",
-            "content": "Hello World!",
+            "content": "SGVsbG8gV29ybGQh",
             "path": "path",
         },
     }

--- a/core/test/observer/test_serialization_observer.py
+++ b/core/test/observer/test_serialization_observer.py
@@ -58,7 +58,7 @@ def test_on_download(observer, published_events):
         "data": {
             "download_url": "http://files.example.com",
             "filename": "test.txt",
-            "content": "SGVsbG8gV29ybGQh",
+            "content": "base64:SGVsbG8gV29ybGQh",
             "path": "path",
         },
     }

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -127,7 +127,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.77.4"
+version = "0.77.5"
 source = { virtual = "." }
 dependencies = [
     { name = "dateparser" },

--- a/sdk/harambe/instrumentation.py
+++ b/sdk/harambe/instrumentation.py
@@ -132,7 +132,7 @@ class HarambeInstrumentation(abc.ABC):
 
             try:
                 result = await func(*args, **kwargs)
-                event["result"] = _safe_repr(result)  # ← UTF-8-safe
+                event["result"] = _safe_repr(result)
 
             except Exception as e:
                 event["result"] = _safe_repr(e)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "harambe-sdk"
-version = "0.77.4"
+version = "0.77.5"
 description = "Data extraction SDK for Playwright 🐒🍌"
 authors = [
     { name = "Adam Watkins", email = "adam@reworkd.ai" }
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.11,<4.0"
 readme = "README.md"
 dependencies = [
-    "harambe_core==0.77.4",
+    "harambe_core==0.77.5",
     "playwright==1.47.0",
     "beautifulsoup4==4.12.3",
     "requests==2.32.3",

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -429,7 +429,7 @@ wheels = [
 
 [[package]]
 name = "harambe-core"
-version = "0.77.4"
+version = "0.77.5"
 source = { editable = "../core" }
 dependencies = [
     { name = "dateparser" },
@@ -462,7 +462,7 @@ dev = [
 
 [[package]]
 name = "harambe-sdk"
-version = "0.77.4"
+version = "0.77.5"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Encode `content` to base64 in `on_download` and update related tests and version numbers.
> 
>   - **Behavior**:
>     - `on_download` in `serialization_observer.py` now encodes `content` to base64.
>     - Updates test cases in `test_json_observer.py` and `test_serialization_observer.py` to reflect base64 encoding.
>   - **Versioning**:
>     - Bump version to `0.77.5` in `pyproject.toml` and `uv.lock` for both `core` and `sdk`.
>   - **Misc**:
>     - Remove UTF-8-safe comment in `instrumentation.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=reworkd%2Fharambe&utm_source=github&utm_medium=referral)<sup> for a4a154d167d1fc475952fcfad191ba3aff3e2006. You can [customize](https://app.ellipsis.dev/reworkd/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->